### PR TITLE
Added support for ffmpeg 1.0.1

### DIFF
--- a/lib/ffprober/parser.rb
+++ b/lib/ffprober/parser.rb
@@ -37,7 +37,8 @@ module Ffprober
         [{major: 0, minor: 9, patch: 0},
          {major: 0, minor: 10, patch: 0},
          {major: 0, minor: 11, patch: 0},
-         {major: 1, minor: 0, patch: 0}]
+         {major: 1, minor: 0, patch: 0},
+		 {major: 1, minor: 0, patch: 1}]
       end
 
       def ffprobe_path


### PR DESCRIPTION
built and tested on Mac OS 10.6.8 and 10.7.5 with ruby 1.9.3-p327

ffprobe changes between ffmpeg 1.0.0 and 1.0.1:

http://git.videolan.org/?p=ffmpeg.git;a=commit;h=2efbff1db314c6a9c0d71ba3638a642dd6cf0ffd

http://git.videolan.org/?p=ffmpeg.git;a=commit;h=a74f292d4ab3e800853c3ab7536418e6eb584b27
