### PR TITLE
enable a video streams bitrate

### DIFF
--- a/lib/ffprober/video_stream.rb
+++ b/lib/ffprober/video_stream.rb
@@ -2,6 +2,6 @@ module Ffprober
   class VideoStream < Stream
     attr_accessor :width, :height, :has_b_frames,
                   :sample_aspect_ratio, :display_aspect_ratio,
-                  :pix_fmt, :level, :is_avc, :nal_length_size
+                  :pix_fmt, :level, :is_avc, :nal_length_size, :bit_rate
   end
 end


### PR DESCRIPTION
expose the bit_rate of a video stream to the VideoStream class

Rational:
The value returned by Format.bit_rate is not the same as the video streams bit_rate. Exposing the video stream bit_rate is useful when setting the -b:v (bitrate video) parameter during ffmpeg encoding.

tested on Mac OS X 10.6 and 10.7 with ruby 1.9.3-p385
