### PR TITLE
ffmpeg 1.1.3 support

### DIFF
--- a/lib/ffprober/parser.rb
+++ b/lib/ffprober/parser.rb
@@ -42,7 +42,8 @@ module Ffprober
           {major: 1, minor: 0, patch: 1},
           {major: 1, minor: 1, patch: 0},
           {major: 1, minor: 1, patch: 1},
-          {major: 1, minor: 1, patch: 2}
+          {major: 1, minor: 1, patch: 2},
+          {major: 1, minor: 1, patch: 3}
         ]
       end
 


### PR DESCRIPTION
added support for ffmpeg 1.1.3

built and tested on OS X 10.6 with ruby 1.9.3-p392
