### PR TITLE
add support for ffmpeg version 2.0.1

### DIFF
--- a/lib/ffprober/ffprobe_version.rb
+++ b/lib/ffprober/ffprobe_version.rb
@@ -4,7 +4,7 @@ module Ffprober
     @@nightly_regex = /^(ffprobe|avprobe|ffmpeg) version (N|git)-/
 
     MIN_VERSION = Gem::Version.new("0.9.0")
-    MAX_VERSION = Gem::Version.new("2.0")
+    MAX_VERSION = Gem::Version.new("2.0.1")
 
     def self.valid?
       self.new.valid?

--- a/spec/assets/version_outputs/osx-2_0_1
+++ b/spec/assets/version_outputs/osx-2_0_1
@@ -1,0 +1,12 @@
+ffprobe version 2.0.1
+built on Aug 15 2013 15:56:26 with gcc 4.2.1 (GCC) (Apple Inc. build 5666) (dot 3)
+configuration: --prefix=/usr/local/Cellar/ffmpeg/2.0.1 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-nonfree --enable-hardcoded-tables --enable-avresample --enable-vda --cc=cc --host-cflags= --host-ldflags= --enable-libx264 --enable-libfaac --enable-libmp3lame --enable-libxvid --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-aacenc
+libavutil      52. 38.100 / 52. 38.100
+libavcodec     55. 18.102 / 55. 18.102
+libavformat    55. 12.100 / 55. 12.100
+libavdevice    55.  3.100 / 55.  3.100
+libavfilter     3. 79.101 /  3. 79.101
+libavresample   1.  1.  0 /  1.  1.  0
+libswscale      2.  3.100 /  2.  3.100
+libswresample   0. 17.102 /  0. 17.102
+libpostproc    52.  3.100 / 52.  3.100


### PR DESCRIPTION
built and tested on Mac OS X 10.6 and 10.7 with ruby 2.0.0p247
