### PR TITLE
wrap file path in quotes to accommodate remote files

### DIFF
--- a/lib/ffprober/parser.rb
+++ b/lib/ffprober/parser.rb
@@ -9,7 +9,7 @@ module Ffprober
                                   (version: #{FfprobeVersion.new.version.to_s})")
         end
 
-        json_output = `#{Ffprober.path} #{@@options} #{file_to_parse}`
+        json_output = `#{Ffprober.path} #{@@options} '#{file_to_parse}'`
         from_json(json_output)
       end
 


### PR DESCRIPTION
Great gem! We were using this to extract metadata and had to add quotes to the file path in order for ffprobe to analyze remote files we were storing on s3. I thought this functionality would be useful to other folks.

I wasn't sure how to test the analysis of remote files without actually hitting a remote file, which would slow test runs considerably. I'd be interested in your thoughts.

Thanks again!
