### PR TITLE
support for ffmpeg/ffprobe version 2.2

### DIFF
--- a/lib/ffprober/ffprobe_version.rb
+++ b/lib/ffprober/ffprobe_version.rb
@@ -4,7 +4,7 @@ module Ffprober
     @@nightly_regex = /^(ffprobe|avprobe|ffmpeg) version (N|git)-/
 
     MIN_VERSION = Gem::Version.new("0.9.0")
-    MAX_VERSION = Gem::Version.new("2.1.4")
+    MAX_VERSION = Gem::Version.new("2.2")
 
     def self.valid?
       self.new.valid?

--- a/spec/assets/version_outputs/osx-2_2
+++ b/spec/assets/version_outputs/osx-2_2
@@ -1,0 +1,11 @@
+ffprobe version 2.2-tessus
+built on Mar 24 2014 22:25:11 with llvm-gcc 4.2.1 (LLVM build 2336.1.00)
+configuration: --prefix=/Users/tessus/data/ext/ffmpeg/sw --as=yasm --extra-version=tessus --disable-shared --enable-static --disable-ffplay --enable-gpl --enable-pthreads --enable-postproc --enable-libmp3lame --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libxvid --enable-libspeex --enable-bzlib --enable-zlib --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libxavs --enable-version3 --enable-libvo-aacenc --enable-libvo-amrwbenc --enable-libvpx --enable-libgsm --enable-libopus --enable-libmodplug --enable-fontconfig --enable-libfreetype --enable-libass --enable-libbluray --enable-filters --enable-runtime-cpudetect
+libavutil      52. 66.100 / 52. 66.100
+libavcodec     55. 52.102 / 55. 52.102
+libavformat    55. 33.100 / 55. 33.100
+libavdevice    55. 10.100 / 55. 10.100
+libavfilter     4.  2.100 /  4.  2.100
+libswscale      2.  5.102 /  2.  5.102
+libswresample   0. 18.100 /  0. 18.100
+libpostproc    52.  3.100 / 52.  3.100

--- a/spec/ffprober/ffprobe_version_spec.rb
+++ b/spec/ffprober/ffprobe_version_spec.rb
@@ -13,7 +13,8 @@ describe Ffprober::FfprobeVersion do
     { version: "2.0.2", pass: true },
     { version: "2.1.1", pass: true },
     { version: "2.1.2", pass: true },
-    {	version: "2.1.4", pass: true }
+    { version: "2.1.4", pass: true },
+    { version: "2.2",   pass: true }
   ]
 
   subject(:ffprobe_version) { Ffprober::FfprobeVersion.new }


### PR DESCRIPTION
built and tested on Mac OS X 10.9.2 with ruby 2.1.1
