### PR TITLE
allow ffmpeg 2.6.3

### DIFF
--- a/lib/ffprober/ffmpeg/version_validator.rb
+++ b/lib/ffprober/ffmpeg/version_validator.rb
@@ -2,7 +2,7 @@ module Ffprober
   module Ffmpeg
     class VersionValidator
       MIN_VERSION = Gem::Version.new("0.9.0")
-      MAX_VERSION = Gem::Version.new("2.6.2")
+      MAX_VERSION = Gem::Version.new("2.6.3")
 
       def initialize(ffmpeg_version)
         @ffmpeg_version = ffmpeg_version


### PR DESCRIPTION
I've run all the ffprober tests and am using ffprober in my application with ffmpeg 2.6.3 without issues.