### PR TITLE
EOL Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
     repo_token: e319ec7d18fb8e1f05b460c3ef8fac58af3844d7bfa3d44de6b82eb874bb3e31
 
 rvm:
-  - 2.0.0-p648
   - 2.1.8
   - 2.2.4
   - 2.3.0


### PR DESCRIPTION
Ruby 2.0 will be EOL'd end of February 2016
