### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/ffprober/parsers/url.rb
+++ b/lib/ffprober/parsers/url.rb
@@ -23,7 +23,7 @@ module Ffprober
       private
 
       def valid_url?(url)
-        URI.escape(url) =~ VALID_URI_REGEX
+        url.gsub(' ', '%20') =~ VALID_URI_REGEX
       end
     end
   end


### PR DESCRIPTION
warning: URI.escape is obsolete